### PR TITLE
Update commandline.js

### DIFF
--- a/lib/commandline.js
+++ b/lib/commandline.js
@@ -64,7 +64,7 @@ module.exports = function (options) {
           break;
         default:
           logHelp();
-          process.kill();
+          process.kill(process.pid);
           break;
       }
     }


### PR DESCRIPTION
Rewrote default: process.kill() according to documentation, by adding process.pid.
W/out process.pid in process.kill — app just crushes w/ exception.

// Offtop:
// By logic, app shouldn't perform suicide after help, or empty call, it should perform exit w/ 0 code, like saying "Well done fellows, I shown you help, and free to go now". But changing behavior to process.exit(0) leads to throwing an exception in events.js:85.
