### PR TITLE
changed importer to keep default tag values, where namespaces are in use

### DIFF
--- a/lib/mongosm.js
+++ b/lib/mongosm.js
@@ -130,8 +130,15 @@ function parse (xmlNode)  {
       break;
 
     case "tag":
-      var key   = "tags." + xmlNode.attributes.k.value.replace(/:/, "."),
-          value = xmlNode.attributes.v.value;
+      var keyRaw = xmlNode.attributes.k.value;
+
+      if (stringContainsSubstring(keyRaw, ':') ) {
+        var key = "tags." + keyRaw.replace(/:/, ".");
+      }else{
+        var key = "tags." + keyRaw + "." + keyRaw;
+      }
+      
+      var value = xmlNode.attributes.v.value;
       entry.set(key, value);
       break;
 
@@ -218,4 +225,11 @@ function prepBaseNode (xmlNode) {
   }
 }
 
+function stringContainsSubstring(str, substr){
+  if(str.indexOf(substr) == -1) {
+    return false;
+  }else{
+    return true;
+  }
+}
 


### PR DESCRIPTION
Thanks for creating this! It helped me already a lot :)
However there is a (fundamental) problem with the code.

# Problem
Name Tags are written like `k=name`, for foreign languages (e.g. english) something `k=name:en`.
In the script the default ones (`k=name`) are overwritten in the db by the ones who follow. This means you lose (the most valuable) data.

### Example (Currently)

```
<tag k="name" v="Tour Eiffel"/>
<tag k="name:en" v="Eiffel Tower"/>
```
**Becomes ↓**

```
{
	"name":{
		"en": "Eiffel Tower"
	}
}
```

The same effect also applies to **lanes**, **wheelchair**, **alt_name** and many more. 

Since we do not know which tags could actually be affected, I propose creating a object for every tag, which then contains also the original one.

### Example (Proposal)

```
<tag k="name" v="Tour Eiffel"/>
<tag k="name:en" v="Eiffel Tower"/>
```
**Becomes ↓**

```
{
	"name":{
		"name": "Tour Eiffel"
		"en": "Eiffel Tower"
	}
}
```

**Note:** For some tags, which never feature a `:` this will be redundant, but I cannot think of another way to not lose valuable information :(